### PR TITLE
Fixed Import of IPancakeFactory.sol from 'Uniswap'

### DIFF
--- a/contracts/PancakeRouter.sol
+++ b/contracts/PancakeRouter.sol
@@ -1,6 +1,6 @@
 pragma solidity =0.6.6;
 
-import '@uniswap/v2-core/contracts/interfaces/IPancakeFactory.sol';
+import '@pancakeswap/pancake-swap-core/contracts/interfaces/IPancakeFactory.sol';
 import '@uniswap/lib/contracts/libraries/TransferHelper.sol';
 
 import './interfaces/IPancakeRouter02.sol';


### PR DESCRIPTION
'IPancakeFactory.sol' is imported from UniswapV2 core directory which will throws an error. So recalled it from pancakeswap-core directory which is actually archieved.